### PR TITLE
Speed up pure Go version of Grain

### DIFF
--- a/grain/grain.go
+++ b/grain/grain.go
@@ -477,47 +477,34 @@ func accumulateGeneric(reg, acc uint64, ms, pt uint16) (reg1, acc1 uint64) {
 	// function to be inlined. However, even though it's inlined
 	// it's only ever called via accumulate, which can't be
 	// inlined because the combined inlining costs exceed the
-	// allowed budget. On a 2019 MBP (i7 @ 2.6Ghz)
-	// accumulateGeneric runs at about 115 MB/s.
-	acctmp := uint16(0)
+	// allowed budget.
+	var acctmp uint16
 	regtmp := uint32(ms) << 16
 	for i := 0; i < 16; i++ {
-		var mask uint64
-		var rem uint32
-		if pt&0x1 != 0 {
-			mask = ^uint64(0)
-			rem = 0xffff
-		}
+		mask := -uint64(pt & 1)
 		acc ^= reg & mask
 		reg >>= 1
 
-		acctmp ^= uint16(regtmp & rem)
+		acctmp ^= uint16(regtmp) & uint16(mask)
 		regtmp >>= 1
 
 		pt >>= 1
 	}
-	// Believe it or not, assinging to reg1 and acc1 causes us to
-	// exceed the inlining budget.
 	return reg | uint64(ms)<<48, acc ^ uint64(acctmp)<<48
 }
 
 func (s *state) accumulate8(ms, pt uint8) {
-	acctmp := uint8(0)
+	var acctmp uint8
 	regtmp := uint16(ms) << 8
 	reg := s.reg
 	acc := s.acc
 
 	for i := 0; i < 8; i++ {
-		var mask uint64
-		var rem uint32
-		if pt&0x1 != 0 {
-			mask = ^uint64(0)
-			rem = 0xff
-		}
+		mask := -uint64(pt & 1)
 		acc ^= reg & mask
 		reg >>= 1
 
-		acctmp ^= uint8(uint32(regtmp) & rem)
+		acctmp ^= uint8(regtmp) & uint8(mask)
 		regtmp >>= 1
 
 		pt >>= 1

--- a/grain/grain_test.go
+++ b/grain/grain_test.go
@@ -132,7 +132,7 @@ func benchmarkKeystream(b *testing.B, fn func(*state) uint32) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		Sink32 = next(&g)
+		Sink32 = fn(&g)
 	}
 }
 


### PR DESCRIPTION
The trick here is that negation turns a single bit into a mask: -0 is all zeros, while -1 is all ones.
    
The pure Go version is now faster than the assembler on amd64:
    
    name           old speed      new speed      delta
    Auth-8         88.7MB/s ± 1%  93.7MB/s ± 1%   +5.60%  (p=0.000 n=10+14)
    AuthGeneric-8  69.0MB/s ± 3%  93.5MB/s ± 1%  +35.61%  (p=0.000 n=10+13)
    Seal1K-8       44.5MB/s ± 3%  46.5MB/s ± 1%   +4.48%  (p=0.000 n=10+14)
    Open1K-8       43.8MB/s ± 1%  46.1MB/s ± 1%   +5.20%  (p=0.000 n=10+15)
    Seal8K-8       45.7MB/s ± 1%  47.5MB/s ± 1%   +3.93%  (p=0.000 n=10+15)
    Open8K-8       44.8MB/s ± 1%  47.1MB/s ± 3%   +5.18%  (p=0.000 n=10+15)
    
If the assembler version of accumulate were removed, the function could be inlined for a further speed boost.