### PR TITLE
ascon: implement permutations in assembly

### DIFF
--- a/ascon/ascon.go
+++ b/ascon/ascon.go
@@ -21,18 +21,18 @@ var errOpen = errors.New("ascon: message authentication failed")
 
 const (
 	// BlockSize128a is the size in bytes of an ASCON-128a block.
-	BlockSize128a = 128 / 8
+	BlockSize128a = 16
 	// BlockSize128 is the size in bytes of an ASCON-128 block.
-	BlockSize128 = 64 / 8
+	BlockSize128 = 8
 	// KeySize is the size in bytes of ASCON-128 and ASCON-128a
 	// keys.
-	KeySize = 128 / 8
+	KeySize = 16
 	// NonceSize is the size in bytes of ASCON-128 and ASCON-128a
 	// nonces.
-	NonceSize = 128 / 8
+	NonceSize = 16
 	// TagSize is the size in bytes of ASCON-128 and ASCON-128a
 	// authenticators.
-	TagSize = 128 / 8
+	TagSize = 16
 )
 
 type ascon struct {

--- a/ascon/ascon_arm64.s
+++ b/ascon/ascon_arm64.s
@@ -1,0 +1,136 @@
+//go:build gc && !purego
+// +build gc,!purego
+
+#include "textflag.h"
+
+#define s_ptr R26
+#define rc R25
+
+#define s0 R0
+#define s1 R1
+#define s2 R2
+#define s3 R3
+#define s4 R4
+
+#define t0 R5
+#define t1 R6
+#define t2 R7
+#define t3 R8
+#define t4 R9
+
+// ROUND completes one permutation round.
+//
+// Uses s{0,1,2,3,4} and t{0,1,2,3,4}.
+//
+// C must start with $.
+#define ROUND(C) \
+	/* Round constant */                             \
+	EOR C, s2, s2; /* s2 ^= C */                     \
+	                                                 \
+	/* Substitution */                               \
+	EOR s4, s0, s0; /* s0 ^= s4 */                   \
+	EOR s3, s4, s4; /* s4 ^= s3 */                   \
+	EOR s1, s2, s2; /* s2 ^= s1 */                   \
+	                                                 \
+	/* Keccak S-box */                               \
+	BIC s1, s2, t0; /* t0 := ^s1 & s2 */             \
+	BIC s2, s3, t1; /* t1 := ^s2 & s3 */             \
+	BIC s3, s4, t2; /* t2 := ^s3 & s4 */             \
+	BIC s4, s0, t3; /* t3 := ^s4 & s0 */             \
+	BIC s0, s1, t4; /* t4 := ^s0 & s1 */             \
+	                                                 \
+	EOR s0, t0, t0; /* t0 ^= s0 */                   \
+	EOR s1, t1, t1; /* t1 ^= s1*/                    \
+	EOR s2, t2, t2; /* t2 ^= s2 */                   \
+	EOR s3, t3, t3; /* t3 ^= s3 */                   \
+	EOR s4, t4, t4; /* t4 ^= s4 */                   \
+	                                                 \
+	/* Substitution */                               \
+	EOR t0, t1, t1; /* t1 ^= t0 */                   \
+	EOR t4, t0, t0; /* t0 ^= t4 */                   \
+	EOR t2, t3, t3; /* t3 ^= t2 */                   \
+	MVN t2, t2; /* t2 = ^t2 */                       \
+	                                                 \
+	EOR t0@>19, t0, s0; /* s0 = t0 ^ rotr(t0, 19) */ \
+	EOR t0@>28, s0, s0; /* s0 ^= rotr(t0, 28) */     \
+	                                                 \
+	EOR t1@>61, t1, s1; /* s1 = t1 ^ rotr(t1, 61) */ \
+	EOR t1@>39, s1, s1; /* s1 ^= rotr(t1, 39) */     \
+	                                                 \
+	EOR t2@>1, t2, s2; /* s2 = t2 ^ rotr(t2, 1) */   \
+	EOR t2@>6, s2, s2; /* s2 ^= rotr(t2, 6) */       \
+	                                                 \
+	EOR t3@>10, t3, s3; /* s3 = t3 ^ rotr(t3, 10) */ \
+	EOR t3@>17, s3, s3; /* s3 ^= rotr(t3, 17) */     \
+	                                                 \
+	EOR t4@>7, t4, s4; /* s4 = t4 ^ rotr(t4, 7) */   \
+	EOR t4@>41, s4, s4; /* s4 ^= rotr(t4, 41) */     \
+	                                                 \
+	/* So the comments line up correctly */          \
+	NOP
+
+// PERM_LOAD loads *state from s+0(FP) into s_ptr.
+#define PERM_LOAD \
+	MOVD s+0(FP), s_ptr;        \
+	                            \
+	LDP  0*16(s_ptr), (s0, s1); \
+	LDP  1*16(s_ptr), (s2, s3); \
+	MOVD 2*16(s_ptr), s4
+
+// PERM_STORE stores s{0,1,2,4} into s_ptr.
+#define PERM_STORE \
+	STP  (s0, s1), 0*16(s_ptr); \
+	STP  (s2, s3), 1*16(s_ptr); \
+	MOVD s4, 2*16(s_ptr)
+
+// func p12(s *state)
+TEXT ·p12(SB), NOSPLIT, $0-8
+	PERM_LOAD
+	ROUND($0xf0)
+	ROUND($0xe1)
+	ROUND($0xd2)
+	ROUND($0xc3)
+	ROUND($0xb4)
+	ROUND($0xa5)
+	ROUND($0x96)
+	ROUND($0x87)
+	ROUND($0x78)
+	ROUND($0x69)
+	ROUND($0x5a)
+	ROUND($0x4b)
+	PERM_STORE
+	RET
+
+// func p8(s *state)
+TEXT ·p8(SB), NOSPLIT, $0-8
+	PERM_LOAD
+	ROUND($0xb4)
+	ROUND($0xa5)
+	ROUND($0x96)
+	ROUND($0x87)
+	ROUND($0x78)
+	ROUND($0x69)
+	ROUND($0x5a)
+	ROUND($0x4b)
+	PERM_STORE
+	RET
+
+// func p6(s *state)
+TEXT ·p6(SB), NOSPLIT, $0-8
+	PERM_LOAD
+	ROUND($0x96)
+	ROUND($0x87)
+	ROUND($0x78)
+	ROUND($0x69)
+	ROUND($0x5a)
+	ROUND($0x4b)
+	PERM_STORE
+	RET
+
+// func round(s *state, C uint64)
+TEXT ·round(SB), NOSPLIT, $0-16
+	PERM_LOAD
+	MOVD C+8(FP), rc
+	ROUND(rc)
+	PERM_STORE
+	RET

--- a/ascon/ascon_noasm.go
+++ b/ascon/ascon_noasm.go
@@ -1,4 +1,5 @@
-// +build !amd64 !gc purego
+//go:build !(amd64 || arm64 || gc) || purego
+// +build !amd64,!arm64,!gc purego
 
 package ascon
 

--- a/ascon/ascon_test.go
+++ b/ascon/ascon_test.go
@@ -15,8 +15,10 @@ import (
 	"testing/quick"
 )
 
+var stateType = reflect.TypeOf([5]uint64{})
+
 func randState(rng *rand.Rand) state {
-	v, ok := quick.Value(reflect.TypeOf([5]uint64{}), rng)
+	v, ok := quick.Value(stateType, rng)
 	if !ok {
 		panic("got false")
 	}

--- a/ascon/stub_arm64.go
+++ b/ascon/stub_arm64.go
@@ -1,0 +1,16 @@
+//go:build gc && !purego
+// +build gc,!purego
+
+package ascon
+
+//go:noescape
+func p12(s *state)
+
+//go:noescape
+func p8(s *state)
+
+//go:noescape
+func p6(s *state)
+
+//go:noescape
+func round(s *state, C uint64)


### PR DESCRIPTION
name           old time/op   new time/op   delta
Seal1K_128a-8   3.12µs ± 0%   2.46µs ± 0%  -21.14%  (p=0.000 n=9+10)
Open1K_128a-8   2.99µs ± 0%   2.31µs ± 0%  -22.76%  (p=0.000 n=9+9)
Seal8K_128a-8   23.8µs ± 0%   18.8µs ± 0%  -21.22%  (p=0.000 n=10+9)
Open8K_128a-8   22.7µs ± 1%   17.5µs ± 0%  -22.93%  (p=0.000 n=10+9)
Seal1K_128-8    4.56µs ± 0%   3.61µs ± 0%  -20.88%  (p=0.000 n=9+9)
Open1K_128-8    4.40µs ± 0%   3.46µs ± 0%  -21.35%  (p=0.000 n=10+9)
Seal8K_128-8    34.9µs ± 0%   27.8µs ± 0%  -20.45%  (p=0.000 n=10+10)
Open8K_128-8    33.6µs ± 0%   26.5µs ± 0%  -21.16%  (p=0.000 n=9+9)

name           old speed     new speed     delta
Seal1K_128a-8  328MB/s ± 0%  416MB/s ± 0%  +26.80%  (p=0.000 n=9+10)
Open1K_128a-8  343MB/s ± 0%  444MB/s ± 0%  +29.50%  (p=0.000 n=10+9)
Seal8K_128a-8  344MB/s ± 0%  437MB/s ± 0%  +26.93%  (p=0.000 n=10+9)
Open8K_128a-8  361MB/s ± 1%  469MB/s ± 0%  +29.75%  (p=0.000 n=10+9)
Seal1K_128-8   225MB/s ± 0%  284MB/s ± 0%  +26.39%  (p=0.000 n=9+9)
Open1K_128-8   233MB/s ± 0%  296MB/s ± 0%  +27.15%  (p=0.000 n=10+9)
Seal8K_128-8   235MB/s ± 0%  295MB/s ± 0%  +25.71%  (p=0.000 n=10+10)
Open8K_128-8   244MB/s ± 0%  309MB/s ± 0%  +26.84%  (p=0.000 n=9+9)

Signed-off-by: Eric Lagergren <eric@ericlagergren.com>